### PR TITLE
Make Getting Started clearer for fresh installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,16 @@ Source code for the frontend of the [Build Canada Outcome Tracker](https://www.b
   git clone https://github.com/BuildCanada/OutcomeTracker.git
   cd OutcomeTracker
   pnpm install
-  pnpm turbo
   ```
 
-### Add/update .env
-- If you're using the production API, set NEXT_PUBLIC_API_URL=https://www.buildcanada.com/tracker/api/v1
-- If you're running the API locally, set NEXT_PUBLIC_API_URL=http://localhost:3000/
+- Copy .env.example to .env
+  - If you're using the production API, set NEXT_PUBLIC_API_URL=https://www.buildcanada.com/tracker/api/v1
+  - If you're running the API locally, set NEXT_PUBLIC_API_URL=http://localhost:3000/
+
+- Run the Frontend
+  ```bash
+  pnpm turbo
+  ```
 
 ## Metrics
 


### PR DESCRIPTION
Re-jigged the order of Getting Started because `.env` and the correct `NEXT_PUBLIC_API_URL` are required for Next to run