### PR TITLE
Fixed promises not pre-fetching on hover. Resized skeleton.

### DIFF
--- a/app/[department]/promises/[promise_id]/page.tsx
+++ b/app/[department]/promises/[promise_id]/page.tsx
@@ -22,20 +22,37 @@ export default function PromisePage() {
     error,
     isLoading,
   } = useSWR<PromiseDetail>(
-    promise_id ? `/tracker/api/v1/promises/${promise_id}.json` : null,
+    promise_id ? `/tracker/api/v1/promises/${promise_id}.json` : null, {
+    revalidateIfStale: false,
+  }
   );
 
   // Handle close modal - navigate to parent department page
   const handleClose = () => {
-    router.push(`/${params.department}`);
+    router.push(`/${params.department}`, { scroll: false });
   };
 
+  // Only show loading if we don't have data AND we're loading
+  const shouldShowLoading = isLoading && !promise;
+
   // Loading state
-  if (isLoading) {
+  if (shouldShowLoading) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-        <div className="bg-white p-8 rounded-lg max-w-md w-full mx-4">
+      <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
+        <div className="bg-white p-8 rounded-lg mx-4 max-w-3xl w-full h-[90vh]">
           <Skeleton className="h-8 w-3/4 mb-4" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-2/3 mb-4" />
+          <Skeleton className="h-32 w-full" />
+
+          <Skeleton className="h-8 w-3/4 mb-4 mt-4" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-full mb-2" />
+          <Skeleton className="h-4 w-2/3 mb-4" />
+          <Skeleton className="h-32 w-full" />
+
+          <Skeleton className="h-8 w-3/4 mb-4 mt-4" />
           <Skeleton className="h-4 w-full mb-2" />
           <Skeleton className="h-4 w-full mb-2" />
           <Skeleton className="h-4 w-2/3 mb-4" />
@@ -48,7 +65,7 @@ export default function PromisePage() {
   // Error state
   if (error) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
         <div className="bg-white p-8 rounded-lg max-w-md w-full mx-4 text-center">
           <h2 className="text-xl font-semibold text-red-600 mb-4">
             Error Loading Promise
@@ -70,7 +87,7 @@ export default function PromisePage() {
   // Promise not found
   if (!promise) {
     return (
-      <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="fixed inset-0 bg-black/80 flex items-center justify-center z-50">
         <div className="bg-white p-8 rounded-lg max-w-md w-full mx-4 text-center">
           <h2 className="text-xl font-semibold text-gray-800 mb-4">
             Promise Not Found

--- a/components/PromiseCard.tsx
+++ b/components/PromiseCard.tsx
@@ -4,6 +4,12 @@ import { useState } from "react";
 import type { PromiseListing } from "@/lib/types";
 import { TrendingUpIcon, XIcon, MinusIcon } from "lucide-react";
 import Link from "next/link";
+import { mutate } from "swr";
+
+// For SWR preload/mutate
+async function fetcher(...args: Parameters<typeof fetch>) {
+  return (await fetch(...args)).json();
+}
 
 export default function PromiseCard({
   promise,
@@ -218,15 +224,16 @@ export default function PromiseCard({
       <Link
         href={`/${departmentSlug}/promises/${promise.id}`}
         className="w-full"
+        onMouseEnter={async () => { // Prefetch the promise data on hover
+          const data = await fetcher(`/tracker/api/v1/promises/${promise.id}.json`);
+          mutate(`/tracker/api/v1/promises/${promise.id}.json`, data);
+        }}
+        scroll={false}
       >
         <div
           className="bg-white border border-[#cdc4bd] flex flex-col cursor-pointer focus:outline-none focus:ring-2 focus:ring-gray-300 group relative"
           tabIndex={0}
           aria-label={promise.text}
-          // onClick={handleCardClick}
-          // onKeyDown={(e) => {
-          //   if (e.key === "Enter" || e.key === " ") handleCardClick();
-          // }}
         >
           <div className="p-6">
             <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">


### PR DESCRIPTION
Fix for issue #97 . 

While the Link component was pre-fetching the Promise page, that prefetch only includes the HTML/JS bundle. The SWR hooks only trigger once the component is mounted. I made it so now it prefetches the promise data on promise card hover, and updates the cache for the Promise Modal. Should be fewer instances of the Skeleton appearing now.

Also resized the Skeleton, to be very close to the actual size of the Promise Modal.