### PR TITLE
Immigration numbers now reflect scraped data

### DIFF
--- a/app/[department]/layout.tsx
+++ b/app/[department]/layout.tsx
@@ -9,6 +9,12 @@ import React, { Usable } from "react";
 import useSWR from "swr";
 import { DEPARTMENTS } from "./_constants";
 import Link from "next/link";
+import { mutate } from "swr";
+
+// For Deparment preload/mutate on hover
+async function fetcher(...args: Parameters<typeof fetch>) {
+  return (await fetch(...args)).json();
+}
 
 export default function Layout({
   children,
@@ -21,6 +27,9 @@ export default function Layout({
 
   const { data: department } = useSWR<Department>(
     `/tracker/api/v1/departments/${slug}.json`,
+    {
+      revalidateIfStale: false,
+    }
   );
 
   if (!department) {
@@ -68,7 +77,6 @@ function DepartmentPillLinks({
 
   // const activeTabId = currentDepartmentSlug;
 
-
   return (
     <div className="flex flex-wrap gap-2 mb-8">
       {DEPARTMENTS.map(({ slug, name }) => {
@@ -77,11 +85,15 @@ function DepartmentPillLinks({
             key={slug}
             href={`/${slug}`}
             className={`px-4 py-2 text-sm font-mono transition-colors
-                        ${
-                          currentDepartmentSlug == slug
-                            ? "bg-[#8b2332] text-white"
-                            : "bg-white text-[#222222] border border-[#d3c7b9] hover:bg-gray-50"
-                        }`}
+              ${currentDepartmentSlug == slug
+                ? "bg-[#8b2332] text-white"
+                : "bg-white text-[#222222] border border-[#d3c7b9] hover:bg-gray-50"
+              }`}
+            onMouseEnter={async () => { // Prefetch department data on hover
+              const data = await fetcher(`/tracker/api/v1/departments/${slug}.json`);
+              mutate(`/tracker/api/v1/departments/${slug}.json`, data);
+            }}
+            scroll={false}
           >
             {name}
           </Link>

--- a/components/charts/NPRPopulationChart.tsx
+++ b/components/charts/NPRPopulationChart.tsx
@@ -47,7 +47,7 @@ interface ChartDataset {
 export default function NPRPopulationChart({
   title = "Proportion of the Canadian population that is made up of non-permanent residents",
   startYear = 2021,
-  endYear = 2024,
+  endYear = new Date().getFullYear(),
   quarterlyData = true,
   showTarget = true,
   targetValue = 5.0,


### PR DESCRIPTION
Fix for #99 

After looking around a bit, it looks like the data is regularly scraped with this [GitHub Action ](https://github.com/BuildCanada/OutcomeTracker/actions/runs/15952873857)

So the data in the local file is kept up to date. The issue was that the chart was hard coded to show up to 2024, I changed it to always show the current year. The actions have been running without errors so the data should continue to be up to date!