### PR TITLE
chore(department-metrics): remove all unused variables reported by eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
     "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/ban-ts-comment": "warn",
     "react/no-unescaped-entities": "warn",
-    "prefer-const": "warn", 
+    "prefer-const": "warn",
     "no-var": "warn",
     "@next/next/no-img-element": "warn",
     "@next/next/no-html-link-for-pages": "warn"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,17 @@ Source code for the frontend of the [Build Canada Outcome Tracker](https://www.b
 
 - 🎉 **Time to explore!** Head over to [http://localhost:4444/tracker](http://localhost:4444/tracker) to see your local instance in action!
 
+## Linting
+
+This project uses ESLint with Next.js configuration. Run linting with:
+
+```bash
+pnpm lint          # Check for linting issues
+pnpm lint:fix      # Auto-fix auto-fixable issues
+```
+
+The linting configuration enforces TypeScript best practices, React rules, and Next.js optimizations while keeping most issues as warnings (temporarily) to avoid blocking development.
+
 ## Metrics
 
 Metrics are scraped using github actions which automatically updates the repo with up to date data. 


### PR DESCRIPTION
Issue: https://github.com/BuildCanada/OutcomeTracker/issues/110

Follow up PR of https://github.com/BuildCanada/OutcomeTracker/pull/116
- remove all unused variables

Report
```5:10  Error: 'Card' is defined but never used.  @typescript-eslint/no-unused-vars
5:16  Error: 'CardContent' is defined but never used.  @typescript-eslint/no-unused-vars
5:29  Error: 'CardHeader' is defined but never used.  @typescript-eslint/no-unused-vars
5:41  Error: 'CardTitle' is defined but never used.  @typescript-eslint/no-unused-vars
7:3  Error: 'Table' is defined but never used.  @typescript-eslint/no-unused-vars
8:3  Error: 'TableBody' is defined but never used.  @typescript-eslint/no-unused-vars
9:3  Error: 'TableCell' is defined but never used.  @typescript-eslint/no-unused-vars
10:3  Error: 'TableHead' is defined but never used.  @typescript-eslint/no-unused-vars
11:3  Error: 'TableHeader' is defined but never used.  @typescript-eslint/no-unused-vars
12:3  Error: 'TableRow' is defined but never used.  @typescript-eslint/no-unused-vars
14:10  Error: 'Badge' is defined but never used.  @typescript-eslint/no-unused-vars
15:10  Error: 'ExternalLink' is defined but never used.  @typescript-eslint/no-unused-vars
18:8  Error: 'BalanceSheetChart' is defined but never used.  @typescript-eslint/no-unused-vars
19:8  Error: 'HousingStartsChart' is defined but never used.  @typescript-eslint/no-unused-vars
286:7  Error: 'getStatusBadgeVariant' is assigned a value but never used.  @typescript-eslint/no-unused-vars```