### PR TITLE
Add Progress Indicator per department

### DIFF
--- a/app/[department]/layout.tsx
+++ b/app/[department]/layout.tsx
@@ -42,7 +42,7 @@ export default function Layout({
 
       <div className="space-y-4">
         {department.minister && (
-          <MinisterHeader minister={department.minister} />
+          <MinisterHeader minister={department.minister} promises={department.promises} />
         )}
         <div className="space-y-4">
           <h3 className="text-2xl">Key Metrics</h3>

--- a/components/MinisterSection.tsx
+++ b/components/MinisterSection.tsx
@@ -252,8 +252,8 @@ export function MinisterHeader({ minister, promises }: { minister: Minister, pro
   const avatarUrl = minister.avatar_url;
 
   return (
-    <div className="flex items-center mb-8 w-full justify-between">
-      <div className="flex items-center">
+    <div className="flex flex-col md:flex-row md:items-center mb-8 w-full md:justify-between">
+      <div className="flex items-center mb-4 md:mb-0">
         {avatarUrl ? (
           <Avatar className="h-20 w-20 mr-6 bg-gray-100">
             <AvatarImage
@@ -275,7 +275,7 @@ export function MinisterHeader({ minister, promises }: { minister: Minister, pro
           <p className="mt-1 text-sm font-mono">{ministerTitle}</p>
         </div>
       </div>
-      <div className="flex flex-col items-start">
+      <div className="flex flex-col">
         <ProgressIndicator promises={promises} />
       </div>
     </div>
@@ -317,7 +317,7 @@ const ProgressIndicator = ({ promises }: { promises: PromiseListing[] }) => {
       <h3 className="text-xl font-semibold mb-1">Promises <span className="text-sm text-gray-600">({promises.length})</span></h3>
 
       {/* Progress Indicator */}
-      <div className="w-64">
+      <div className="w-full md:w-64">
         <div className="flex h-4 w-full rounded overflow-hssidden border border-gray-200 mb-2">
           {promises.map((p, index) => {
 

--- a/components/MinisterSection.tsx
+++ b/components/MinisterSection.tsx
@@ -307,24 +307,23 @@ const ProgressIndicator = ({ promises }: { promises: PromiseListing[] }) => {
     return progressA - progressB;
   });
 
-  // Count the different progress scores
-  const notStarted = promises.filter(p => (p.progress_score ?? 0) === 0).length;
-  const inProgress = promises.filter(p => p.progress_score && p.progress_score > 0 && p.progress_score < 5).length;
-  const done = promises.filter(p => p.progress_score === 5).length;
-
   return (
     <>
-      <h3 className="text-xl font-semibold mb-1">Promises <span className="text-sm text-gray-600">({promises.length})</span></h3>
+      <h3 className="text-xl font-semibold mb-1">Promises</h3>
 
       {/* Progress Indicator */}
       <div className="w-full md:w-64">
-        <div className="flex h-4 w-full rounded overflow-hssidden border border-gray-200 mb-2">
+        <div className="flex h-4 w-full rounded border border-gray-200 mb-2">
           {promises.map((p, index) => {
+            let progressColor = "bg-gray-300"; // 0 (not started, default color)
 
-            // Progress color
-            let progressColor = "bg-gray-300";
-            if (p.progress_score && p.progress_score > 0 && p.progress_score < 5) progressColor = "bg-yellow-400";
-            else if (p.progress_score === 5) progressColor = "bg-green-500";
+            if (p.progress_score && p.progress_score > 0 && p.progress_score < 5) {
+              // 5-point scale for in-progress promises
+              if (p.progress_score === 1) progressColor = "bg-yellow-300"; // Early progress made
+              else if (p.progress_score === 2) progressColor = "bg-amber-300"; // Some progress made
+              else if (p.progress_score === 3) progressColor = "bg-orange-300"; // Good progress made
+              else if (p.progress_score === 4) progressColor = "bg-lime-400"; // Almost complete
+            } else if (p.progress_score === 5) progressColor = "bg-green-600"; // Done
 
             // Add a tiny right border except for the last chunk (to view each promise easily)
             const border = index < promises.length - 1 ? "border-r border-white" : "";
@@ -332,7 +331,7 @@ const ProgressIndicator = ({ promises }: { promises: PromiseListing[] }) => {
             return (
               <div
                 key={p.id}
-                className={`h-full flex-1 min-w-0 ${progressColor} ${border} cursor-pointer relative`}
+                className={`h-full flex-1 min-w-0 ${progressColor} ${border} cursor-help relative`}
                 style={{ minWidth: 0 }}
                 onMouseEnter={() => setHoveredIndex(index)}
                 onMouseLeave={() => setHoveredIndex(null)}
@@ -349,23 +348,23 @@ const ProgressIndicator = ({ promises }: { promises: PromiseListing[] }) => {
           })}
         </div>
 
-        {/* Colored progress bars */}
-        <div className="flex gap-4 text-xs text-gray-600 mt-1 relative">
+        {/* Legend with 3 categories */}
+        <div className="flex gap-4 text-xs text-gray-600 mt-1">
           <span>
             <span className="inline-block w-3 h-3 bg-gray-300 mr-1 rounded-sm align-middle" />
-            Not started ({notStarted})
+            Not started
           </span>
           <span>
-            <span className="inline-block w-3 h-3 bg-yellow-400 mr-1 rounded-sm align-middle" />
-            In progress ({inProgress})
+            <span className="inline-block w-3 h-3 bg-yellow-300 mr-1 rounded-sm align-middle" />
+            <span className="inline-block w-3 h-3 bg-lime-400 mr-1 rounded-sm align-middle" />
+            In progress
           </span>
           <span>
-            <span className="inline-block w-3 h-3 bg-green-500 mr-1 rounded-sm align-middle" />
-            Done ({done})
+            <span className="inline-block w-3 h-3 bg-green-600 mr-1 rounded-sm align-middle" />
+            Done
           </span>
         </div>
       </div>
-
     </>
   );
 }

--- a/components/PromiseCard.tsx
+++ b/components/PromiseCard.tsx
@@ -11,6 +11,17 @@ async function fetcher(...args: Parameters<typeof fetch>) {
   return (await fetch(...args)).json();
 }
 
+// Human-friendly progress tooltip
+export function getProgressTooltip(progressScore: number): string {
+  if (progressScore === 0) return "No progress made yet";
+  else if (progressScore === 1) return "Early progress made";
+  else if (progressScore === 2) return "Some progress made";
+  else if (progressScore === 3) return "Good progress made";
+  else if (progressScore === 4) return "Almost complete";
+  else if (progressScore === 5) return "Complete";
+  else return "Unknown";
+}
+
 export default function PromiseCard({
   promise,
   departmentSlug,
@@ -26,13 +37,7 @@ export default function PromiseCard({
   const progressScore = promise.progress_score || 0; // 1-5
 
   // Human-friendly progress tooltip
-  let progressTooltip = "";
-  if (progressScore === 0) progressTooltip = "No progress made yet";
-  else if (progressScore === 1) progressTooltip = "Early progress made";
-  else if (progressScore === 2) progressTooltip = "Some progress made";
-  else if (progressScore === 3) progressTooltip = "Good progress made";
-  else if (progressScore === 4) progressTooltip = "Almost complete";
-  else if (progressScore === 5) progressTooltip = "Complete";
+  let progressTooltip = getProgressTooltip(progressScore);
 
   // Impact Indicator
   const impactRankRaw = promise.bc_promise_rank ?? "";


### PR DESCRIPTION
Solution for #49 

Next to each Minister Header, there is now a visual Progress Indicator. This gives the user quick and visual feedback as to each department's progress towards their promises. The indicator is broken up by each promise, so you can hover each for individual information.

It uses already fetched data as well so it won't affect performance at all!