### PR TITLE
feat: add more linear regression trendline

### DIFF
--- a/components/charts/DefenseSpendingChart.tsx
+++ b/components/charts/DefenseSpendingChart.tsx
@@ -12,8 +12,9 @@ import {
   Legend,
 } from "chart.js/auto";
 import defenseData from "@/metrics/worldbank/defense-spending.json";
-import { getPrimaryLineStyling, getTargetLineStyling } from "@/components/charts/utils/styling";
+import { getPrimaryLineStyling, getTargetLineStyling, getTrendLineStyling } from "@/components/charts/utils/styling";
 import { LineChartDataset } from "@/components/charts/types";
+import { calculateLinearTrend } from "./utils/trendCalculator";
 
 ChartJS.register(
   CategoryScale,
@@ -31,6 +32,7 @@ interface DefenseSpendingChartProps {
   endYear?: number;
   showTarget?: boolean;
   targetValue?: number;
+  showTrend?: boolean;
 }
 
 
@@ -40,6 +42,7 @@ export default function DefenseSpendingChart({
   endYear = 2029,
   showTarget = true,
   targetValue = 2.0,
+  showTrend = true,
 }: DefenseSpendingChartProps) {
   // Get defense spending data
   const defenseDataObj = defenseData as any;
@@ -68,6 +71,16 @@ export default function DefenseSpendingChart({
       ...getPrimaryLineStyling(),
     },
   ];
+
+  // Calculate and add trend line
+  if (showTrend && chartValues.length > 1) {
+    const trendValues = calculateLinearTrend(chartValues);
+    datasets.push({
+      label: "Trend",
+      data: trendValues,
+      ...getTrendLineStyling(),
+    });
+  }
 
   // Add target line if requested
   if (showTarget && targetValue) {

--- a/components/charts/ElectricityCapacityChart.tsx
+++ b/components/charts/ElectricityCapacityChart.tsx
@@ -70,12 +70,6 @@ export default function ElectricityCapacityChart({
     (dataPoint) => dataPoint[1] as number
   );
 
-  // Calculate linear trend line if requested
-  let trendValues: number[] = [];
-  if (showTrend && capacityValues.length > 1) {
-    trendValues = calculateLinearTrend(capacityValues);
-  }
-
   // Configure datasets for the chart
   const datasets: LineChartDataset[] = [
     {
@@ -89,8 +83,9 @@ export default function ElectricityCapacityChart({
     },
   ];
 
-  // Add trend line if requested
-  if (showTrend && trendValues.length > 0) {
+  // Calculate and add trend line if requested
+  if (showTrend && capacityValues.length > 1) {
+    const trendValues = calculateLinearTrend(capacityValues);
     datasets.push({
       label: "Trend",
       data: trendValues,

--- a/components/charts/ElectricityProductionChart.tsx
+++ b/components/charts/ElectricityProductionChart.tsx
@@ -13,6 +13,8 @@ import {
   ChartOptions,
 } from "chart.js/auto";
 import electricityProductionData from "@/metrics/statscan/electricity-production.json";
+import { calculateLinearTrend } from "./utils/trendCalculator";
+import { getTrendLineStyling } from "./utils/styling";
 
 ChartJS.register(
   CategoryScale,
@@ -90,21 +92,6 @@ export default function ElectricityProductionChart({
       }
     });
 
-  // Calculate linear trend line if requested
-  let trendValues: number[] = [];
-  if (showTrend && productionValues.length > 1) {
-    const n = productionValues.length;
-    const sumX = years.reduce((sum: number, _: string, index: number) => sum + index, 0);
-    const sumY = productionValues.reduce((sum: number, val: number) => sum + val, 0);
-    const sumXY = productionValues.reduce((sum: number, val: number, index: number) => sum + (index * val), 0);
-    const sumX2 = years.reduce((sum: number, _: string, index: number) => sum + (index * index), 0);
-
-    const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
-    const intercept = (sumY - slope * sumX) / n;
-
-    trendValues = years.map((_: string, index: number) => intercept + slope * index);
-  }
-
   // Configure datasets for the chart
   const datasets: ChartDataset[] = [
     {
@@ -118,17 +105,13 @@ export default function ElectricityProductionChart({
     },
   ];
 
-  // Add trend line if requested
-  if (showTrend && trendValues.length > 0) {
+  // Calculate and add trend line if requested
+  if (showTrend && productionValues.length > 1) {
+    const trendValues = calculateLinearTrend(productionValues);
     datasets.push({
       label: "Trend",
       data: trendValues,
-      borderColor: "rgb(255, 140, 0)",
-      backgroundColor: "rgba(255, 140, 0, 0.5)",
-      tension: 0,
-      borderDash: [5, 5],
-      pointRadius: 0,
-      borderWidth: 2,
+      ...getTrendLineStyling(),
     });
   }
 

--- a/components/charts/FederalPhysicianSupplyChart.tsx
+++ b/components/charts/FederalPhysicianSupplyChart.tsx
@@ -13,7 +13,8 @@ import {
 } from "chart.js/auto";
 import physicianData from "@/metrics/cihi/physician_supply.json";
 import { LineChartDataset } from "@/components/charts/types";
-import { getPrimaryLineStyling } from "./utils/styling";
+import { getPrimaryLineStyling, getTrendLineStyling } from "./utils/styling";
+import { calculateLinearTrend } from "./utils/trendCalculator";
 
 ChartJS.register(
   CategoryScale,
@@ -30,6 +31,7 @@ interface FederalPhysicianSupplyChartProps {
   startYear?: number;
   endYear?: number;
   height?: number;
+  showTrend?: boolean;
 }
 
 export default function FederalPhysicianSupplyChart({
@@ -37,6 +39,7 @@ export default function FederalPhysicianSupplyChart({
   startYear = 2019,
   endYear = 2029,
   height = 400,
+  showTrend = true,
 }: FederalPhysicianSupplyChartProps) {
   // Get federal physician supply data
   const physicianDataObj = physicianData as any;
@@ -64,6 +67,16 @@ export default function FederalPhysicianSupplyChart({
       ...getPrimaryLineStyling(),
     },
   ];
+
+  // Calculate and add trend line
+  if (showTrend && chartValues.length > 1) {
+    const trendValues = calculateLinearTrend(chartValues);
+    datasets.push({
+      label: "Trend",
+      data: trendValues,
+      ...getTrendLineStyling(),
+    });
+  }
 
   const chartData = {
     labels,

--- a/components/charts/FederalPhysicianSupplyPerCapitaChart.tsx
+++ b/components/charts/FederalPhysicianSupplyPerCapitaChart.tsx
@@ -13,8 +13,9 @@ import {
 } from "chart.js/auto";
 import physicianData from "@/metrics/cihi/physician_supply.json";
 import populationData from "@/metrics/statscan/population.json";
-import { getPrimaryLineStyling, getTargetLineStyling } from "@/components/charts/utils/styling";
+import { getPrimaryLineStyling, getTargetLineStyling, getTrendLineStyling } from "@/components/charts/utils/styling";
 import { LineChartDataset } from "@/components/charts/types";
+import { calculateLinearTrend } from "./utils/trendCalculator";
 
 ChartJS.register(
   CategoryScale,
@@ -33,6 +34,7 @@ interface FederalPhysicianSupplyPerCapitaChartProps {
   height?: number;
   showTarget?: boolean;
   targetValue?: number;
+  showTrend?: boolean;
 }
 
 export default function FederalPhysicianSupplyPerCapitaChart({
@@ -42,6 +44,7 @@ export default function FederalPhysicianSupplyPerCapitaChart({
   height = 400,
   showTarget = true,
   targetValue = 3.5,
+  showTrend = true,
 }: FederalPhysicianSupplyPerCapitaChartProps) {
   // Get federal physician supply data
   const physicianDataObj = physicianData as any;
@@ -93,6 +96,16 @@ export default function FederalPhysicianSupplyPerCapitaChart({
       ...getPrimaryLineStyling(),
     },
   ];
+
+  // Calculate and add trend line
+  if (showTrend && chartValues.length > 1) {
+    const trendValues = calculateLinearTrend(chartValues);
+    datasets.push({
+      label: "Trend",
+      data: trendValues,
+      ...getTrendLineStyling(),
+    });
+  }
 
   // Add target line if requested
   if (showTarget && targetValue) {

--- a/components/charts/GDPPerCapitaChart.tsx
+++ b/components/charts/GDPPerCapitaChart.tsx
@@ -125,13 +125,8 @@ export default function GDPPerCapitaChart({
   }
 
   // Calculate linear trend if requested
-  let trendValues: (number | null)[] = [];
   if (showTrend && alignedGrowthRates.length > 1) {
-    trendValues = calculateLinearTrend(alignedGrowthRates as number[]);
-  }
-  
-  // Add trend line if requested
-  if (showTrend && trendValues.length > 0) {
+    const trendValues = calculateLinearTrend(alignedGrowthRates as number[]);
     datasets.push({
       label: "Trend",
       data: trendValues,

--- a/components/charts/LabourProductivityGrowthChart.tsx
+++ b/components/charts/LabourProductivityGrowthChart.tsx
@@ -12,8 +12,9 @@ import {
   Legend,
 } from "chart.js/auto";
 import labourProductivityData from "@/metrics/statscan/labour-productivity.json";
-import { getPrimaryLineStyling, getTargetLineStyling } from "@/components/charts/utils/styling";
+import { getPrimaryLineStyling, getTargetLineStyling, getTrendLineStyling } from "@/components/charts/utils/styling";
 import { LineChartDataset } from "@/components/charts/types";
+import { calculateLinearTrend } from "./utils/trendCalculator";
 
 ChartJS.register(
   CategoryScale,
@@ -34,6 +35,7 @@ interface LabourProductivityGrowthChartProps {
   showTarget?: boolean;
   targetValue?: number;
   showProductivityIndex?: boolean;
+  showTrend?: boolean;
 }
 
 
@@ -46,6 +48,7 @@ export default function LabourProductivityGrowthChart({
   showTarget = true,
   targetValue = 2.0,
   showProductivityIndex = false,
+  showTrend = true,
 }: LabourProductivityGrowthChartProps) {
   // Get data for selected sector
   const productivityDataObj = labourProductivityData as any;
@@ -107,6 +110,16 @@ export default function LabourProductivityGrowthChart({
       ...getPrimaryLineStyling({ yAxisID: "y" }),
     },
   ];
+
+  // Calculate and add trend line
+  if (showTrend && alignedGrowthRates.length > 1) {
+    const trendValues = calculateLinearTrend(alignedGrowthRates as number[]);
+    datasets.push({
+      label: "Trend",
+      data: trendValues,
+      ...getTrendLineStyling(),
+    });
+  }
 
   // Add productivity index if requested
   if (showProductivityIndex) {

--- a/components/charts/ProductivityChart.tsx
+++ b/components/charts/ProductivityChart.tsx
@@ -96,12 +96,6 @@ export default function ProductivityChart({
     growthRates = [...padding, ...growthRates];
   }
 
-  // Calculate linear trend if requested
-  let trendValues: number[] = [];
-  if (showTrend && productivityValues.length > 1) {
-    trendValues = calculateLinearTrend(productivityValues);
-  }
-
   const datasets: LineChartDataset[] = [
     {
       label: "Productivity Index",
@@ -110,8 +104,9 @@ export default function ProductivityChart({
     },
   ];
 
-  // Add trend line if requested
-  if (showTrend && trendValues.length > 0) {
+  // Calculate linear trend if requested
+  if (showTrend && productivityValues.length > 1) {
+    const trendValues = calculateLinearTrend(productivityValues);
     datasets.push({
       label: "Trend",
       data: trendValues,


### PR DESCRIPTION
**WHAT**
- partial implementation of https://github.com/BuildCanada/OutcomeTracker/issues/128
- implements all linear regression trend line
- 8 files changed, 8 trend lines shown

**Snapshots**
<img width="774" height="631" alt="Screenshot 2025-07-12 at 9 52 24 PM" src="https://github.com/user-attachments/assets/63e3c08e-46a2-4a2d-863c-0f2775c8666c" />
<img width="774" height="631" alt="Screenshot 2025-07-12 at 9 52 44 PM" src="https://github.com/user-attachments/assets/76c148f7-e7eb-4ece-8fc3-c1b580ef7418" />
<img width="774" height="631" alt="Screenshot 2025-07-12 at 9 52 53 PM" src="https://github.com/user-attachments/assets/4315f908-ac23-4e42-9ebf-5cfc0439a104" />
<img width="774" height="631" alt="Screenshot 2025-07-12 at 9 53 03 PM" src="https://github.com/user-attachments/assets/57593615-af0a-4be9-89b1-57729b90b3ba" />
<img width="774" height="631" alt="Screenshot 2025-07-12 at 9 53 10 PM" src="https://github.com/user-attachments/assets/0a214580-6128-44d9-88dd-4f50283841ec" />
<img width="774" height="631" alt="Screenshot 2025-07-12 at 9 53 21 PM" src="https://github.com/user-attachments/assets/2bc2a6d6-7793-4e76-ba22-e2986fd00fea" />
