### PR TITLE
Added anchor link for reporting issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_URL=https://www.buildcanada.com/tracker/api/v1

--- a/components/PromiseModal.tsx
+++ b/components/PromiseModal.tsx
@@ -357,6 +357,15 @@ export default function PromiseModal({
                 </div>
               )}
             </section>
+
+            {/*Report Issue section*/}
+            <section className="border-t border-[#d3c7b9] pt-6">
+              <div className="text-[#0056b3]">
+                <a href="mailto:hi@buildcanada.ca?subject=Outcome Tracker Bug">
+                  Report an Issue
+                </a>
+              </div>
+            </section>
           </div>
 
           {/* Modal Footer */}


### PR DESCRIPTION
Added an anchor link that sends to default email with a subject line in the promise modal 