### PR TITLE
Fix public Outcome Tracker MCP endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ If linting fails, the commit will be blocked until issues are resolved.
 
 Metrics are scraped using github actions which automatically updates the repo with up to date data.
 
+## MCP server
+
+The tracker API exposes a read-only Model Context Protocol endpoint at
+`https://www.buildcanada.com/tracker/mcp`. The frontend proxies this endpoint to
+the Rails API alongside the JSON API routes.
+
 ## Contributing
 
 We would love to have your help! Please fill in our volunteer [intake form](https://5nneq7.share-na3.hsforms.com/2l9iIH2gFSomphjDe-ci5OQ).

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -49,6 +49,10 @@ const nextConfig = {
         source: "/api/dashboard/:path*",
         destination: `${process.env.NEXT_PUBLIC_API_URL}/api/dashboard/:path*`,
       },
+      {
+        source: "/mcp",
+        destination: `${process.env.NEXT_PUBLIC_API_URL}/mcp`,
+      },
     ];
   },
 };


### PR DESCRIPTION
## Summary

- proxy `POST /tracker/mcp` through the Next.js frontend to the Rails API `POST /mcp` route
- document the public MCP endpoint in the frontend repository

## Why

The Rails API added its MCP server in BuildCanada/OutcomeTrackerAPI#117 and documents the public URL as `https://www.buildcanada.com/tracker/mcp`. The production frontend currently returns its own 404 for that URL because `next.config.mjs` proxies the JSON API routes but has no MCP rewrite.

The existing Rails JSON API remains reachable through the frontend, confirming the API proxy/origin is live. This adds the missing cross-repo routing piece.

## Verification

- imported `next.config.mjs` with a test API origin and asserted `/mcp` resolves to `<origin>/mcp`
- `prettier --check next.config.mjs README.md`
- `git diff --check`

The live URL will still return 404 until this frontend change is merged and deployed.